### PR TITLE
Always convert hashed password to string

### DIFF
--- a/audtekapi/__init__.py
+++ b/audtekapi/__init__.py
@@ -225,7 +225,7 @@ def _get_hashed_password(user_password, salt):
     hash_bytes = hashlib.sha256(salt_bytes + password_encoded).digest()
     hashed_password = binascii.hexlify(salt_bytes + hash_bytes).upper()
 
-    return hashed_password
+    return bytes(hashed_password).decode()
 
 
 def _post(endpoint, credentials, session=None, data=None, headers=None):


### PR DESCRIPTION
Everything works fine in Python2 but in Python3 binascii.hexlify
returns bytes object which is handled differently by HTTPDigestAuth.

It seems to work on python 2.7 and python 3.7